### PR TITLE
feature: add libvirt/qemu service discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
 		build-essential \
+		libvirt-dev \
+		pkg-config \
 		python3 \
 		python3-dev \
 		python3-venv \
@@ -67,6 +69,7 @@ RUN \
 		gpg-agent \
 		inotify-tools \
 		iproute2 \
+		libvirt0 \
 		net-tools \
 		python3 \
 		python3-distutils \

--- a/dalidock
+++ b/dalidock
@@ -341,7 +341,16 @@ class LibvirtEventsHandler(object):
 
             self.handleDomainSafe(dom, "Started")
 
-    def handleDomainSafe(self, dom, event):
+    def handleDomainSafe(self, dom, event, start_thread=True):
+        # re-call in background thread
+        if start_thread:
+            return threading.Thread(
+                target=self.handleDomainSafe,
+                args=(dom, event),
+                kwargs={"start_thread": False},
+                daemon=True,
+            ).start()
+
         # if domain has just been started, wait for IP address to be known before trying to lock
         # config for update (other newly started container/domain may already be ready)
         if event == "Started":

--- a/dalidock
+++ b/dalidock
@@ -377,6 +377,14 @@ class LibvirtEventsHandler:
         ):
             return
 
+        # ignore invalid operation errors (caused when trying to get IP on domain shutdown)
+        # pylint: disable=bad-continuation
+        if (
+            cb_error[0] == libvirt.VIR_ERR_OPERATION_INVALID
+            and cb_error[1] == libvirt.VIR_FROM_QEMU
+        ):
+            return
+
         log("libvirt error: [%d, %d] %s" % (cb_error[0], cb_error[1], cb_error[2]))
 
     def loadAllDomains(self):

--- a/dalidock
+++ b/dalidock
@@ -21,7 +21,7 @@ import docker
 DOCKER_SOCKET = os.getenv("DOCKER_SOCKET", "unix://var/run/docker.sock")
 
 # libvirt default values
-LIBVIRT_SOCKET = os.getenv("LIBVIRT_SOCKET", "/var/run/libvirt/libvirt-sock-ro")
+LIBVIRT_SOCKET = os.getenv("LIBVIRT_SOCKET", "/var/run/libvirt/libvirt-sock")
 LIBVIRT_IP_TIMEOUT = float(os.getenv("LIBVIRT_IP_TIMEOUT", "30.0"))
 
 # DNS default values
@@ -148,9 +148,9 @@ DOM_EVENTS = Description(
 
 
 class LibvirtQemuClient:
-    def __init__(self, socket_path="unix://var/run/docker.sock"):
+    def __init__(self, socket_path="/var/run/libvirt/libvirt-sock"):
         self.socket = socket_path
-        self.conn = libvirt.openReadOnly(name="qemu:///system?socket=%s" % (self.socket))
+        self.conn = libvirt.open(name="qemu:///system?socket=%s" % (self.socket))
 
         self.showInformations()
 
@@ -189,6 +189,18 @@ class LibvirtQemuClient:
     def getIPAddress(self, dom, timeout=None):
         # return domain main IP address
 
+        guest_agent = xml.etree.ElementTree.fromstring(dom.XMLDesc()).find(
+            ".//channel/target[@name='org.qemu.guest_agent.0']"
+        )
+
+        if guest_agent is None:
+            return self.getIPAddressFromDhcpLease(dom, timeout=timeout)
+
+        return self.getIPAddressFromGuestAgent(dom, timeout=timeout)
+
+    def getIPAddressFromDhcpLease(self, dom, timeout=None):
+        # return domain main IP address
+
         net_infos = self.getNetworkInfos(dom)
         started_at = float(time.time())
 
@@ -219,17 +231,57 @@ class LibvirtQemuClient:
 
         return None
 
+    def getIPAddressFromGuestAgent(self, dom, timeout=None):
+        # return domain main IP address
+
+        net_infos = self.getNetworkInfos(dom)
+        started_at = float(time.time())
+
+        while timeout is None or time.time() < started_at + timeout:
+            try:
+                iface_addresses = dom.interfaceAddresses(
+                    libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT
+                )
+            except libvirt.libvirtError:
+                iface_addresses = {}
+
+            for iface, data in iface_addresses.items():
+                if data.get("hwaddr") != net_infos.get("mac"):
+                    continue
+
+                for addr in data.get("addrs"):
+                    if addr.get("type") != libvirt.VIR_IP_ADDR_TYPE_IPV4:
+                        continue
+
+                    if timeout is not None:
+                        log(
+                            "found domain IP address after %.2f seconds on guest's %s"
+                            % (time.time() - started_at, iface)
+                        )
+
+                    return addr.get("addr")
+
+            # no timeout set, return after first attempt
+            if timeout is None:
+                return None
+
+            # wait for 200ms before re-trying
+            time.sleep(0.2)
+
+        return None
+
     def getNetworkInfos(self, dom):
         # return first network name
 
         xml_root = xml.etree.ElementTree.fromstring(dom.XMLDesc())
-        xml_iface = xml_root.find(".//interface")
+        xml_iface_src = xml_root.find(".//interface/source")
+        xml_iface_mac = xml_root.find(".//interface/mac")
 
-        if xml_iface is None or xml_iface.get("type") != "bridge":
+        if xml_iface_src is None or xml_iface_mac is None or xml_iface_src.get("bridge") is None:
             return dict()
 
-        mac_addr = xml_iface.find(".//mac").get("address")
-        bridge_iface = xml_iface.find(".//source").get("bridge")
+        mac_addr = xml_iface_mac.get("address")
+        bridge_iface = xml_iface_src.get("bridge")
 
         return {"mac": mac_addr, "iface": bridge_iface}
 

--- a/dalidock
+++ b/dalidock
@@ -385,6 +385,14 @@ class LibvirtEventsHandler:
         ):
             return
 
+        # ignore qemu agent errors
+        # pylint: disable=bad-continuation
+        if (
+            cb_error[0] == libvirt.VIR_ERR_AGENT_UNRESPONSIVE
+            and cb_error[1] == libvirt.VIR_FROM_QEMU
+        ):
+            return
+
         log("libvirt error: [%d, %d] %s" % (cb_error[0], cb_error[1], cb_error[2]))
 
     def loadAllDomains(self):

--- a/dalidock
+++ b/dalidock
@@ -269,7 +269,7 @@ class LibvirtQemuClient(object):
 
 
 class LibvirtEventsHandler(object):
-    def __init__(self, dns_entries, lb_entries):
+    def __init__(self, dns_entries, lb_entries, config_lock):
         # note: event loop need to be registered before opening connection to libvirt
         libvirt.virEventRegisterDefaultImpl()
 
@@ -283,6 +283,7 @@ class LibvirtEventsHandler(object):
         self.libvirt = LibvirtQemuClient(LIBVIRT_SOCKET)
         self.dns = dns_entries
         self.lb = lb_entries
+        self.config_lock = config_lock
         self.event_loop_thread = None
         self.loop = True
 
@@ -319,11 +320,11 @@ class LibvirtEventsHandler(object):
         )
 
         if str(DOM_EVENTS[event]) in ["Started", "Stopped"]:
-            self.handleDomain(dom, str(DOM_EVENTS[event]))
+            self.handleDomainSafe(dom, str(DOM_EVENTS[event]))
 
         # if definition is updated while domain is running, emulate 'Started' event
         elif str(DOM_EVENTS[event]) == "Defined" and dom.state()[0] == libvirt.VIR_DOMAIN_RUNNING:
-            self.handleDomain(dom, "Started")
+            self.handleDomainSafe(dom, "Started")
 
     def errorCallback(self, unused, error):
         # ignore empty metadata errors
@@ -337,7 +338,12 @@ class LibvirtEventsHandler(object):
             if dom.state()[0] != libvirt.VIR_DOMAIN_RUNNING:
                 continue
 
-            self.handleDomain(dom, "Started")
+            self.handleDomainSafe(dom, "Started")
+
+    def handleDomainSafe(self, dom, event):
+
+        with self.config_lock:
+            self.handleDomain(dom, event)
 
     def handleDomain(self, dom, event):
         cid = "libvirt-qemu-%s" % (self.libvirt.getId(dom))
@@ -470,11 +476,12 @@ class DockerClient(object):
 
 
 class DockerEventsHandler(object):
-    def __init__(self, dns_entries, lb_entries):
+    def __init__(self, dns_entries, lb_entries, config_lock):
         self.docker = DockerClient(DOCKER_SOCKET)
         self.myid = self.getMyCid()
         self.dns = dns_entries
         self.lb = lb_entries
+        self.config_lock = config_lock
         self.loop = True
 
     def serve(self):
@@ -545,11 +552,11 @@ class DockerEventsHandler(object):
 
         log("registering dalidock container in DNS")
 
-        self.handleContainer(myid, "start")
+        self.handleContainerSafe(myid, "start")
 
     def loadAllContainers(self):
         for container in self.docker.conn.containers():
-            self.handleContainer(container["Id"], "start")
+            self.handleContainerSafe(container["Id"], "start")
 
     def processEvt(self, evt):
         evt = json.loads(evt)
@@ -565,7 +572,11 @@ class DockerEventsHandler(object):
             # These events can be dropped as we are not handling them
             return
 
-        self.handleContainer(containerid, status)
+        self.handleContainerSafe(containerid, status)
+
+    def handleContainerSafe(self, containerid, status):
+        with self.config_lock:
+            self.handleContainer(containerid, status)
 
     def handleContainer(self, containerid, status):
         data = self.docker.getContainerData(containerid)
@@ -892,12 +903,13 @@ signal.signal(signal.SIGTERM, sighandler)
 
 def main():
     # prepare data models
+    config_lock = threading.Lock()
     dns_entries = DnsEntries()
     lb_entries = LoadbalancerEntries(dns_entries)
 
     # prepare event handlers
-    libvirt_evt_handler = LibvirtEventsHandler(dns_entries, lb_entries)
-    docker_evt_handler = DockerEventsHandler(dns_entries, lb_entries)
+    libvirt_evt_handler = LibvirtEventsHandler(dns_entries, lb_entries, config_lock)
+    docker_evt_handler = DockerEventsHandler(dns_entries, lb_entries, config_lock)
 
     # update myid attribute (gotten from docker client)
     dns_entries.setMyId(docker_evt_handler.myid)

--- a/dalidock
+++ b/dalidock
@@ -186,21 +186,28 @@ class LibvirtQemuClient(object):
         # return domain name
         return dom.name()
 
-    def getIPAddress(self, dom):
+    def getIPAddress(self, dom, timeout=0):
         # return domain main IP address
 
         net_infos = self.getNetworkInfos(dom)
+        started_at = float(time.time())
 
         for network in self.conn.listAllNetworks():
             if not hasattr(network, "bridgeName") or network.bridgeName() != net_infos.get("iface"):
                 continue
 
-            leases = network.DHCPLeases()
-            for lease in sorted(leases, key=lambda item: item.get("expirytime"), reverse=True):
-                if lease.get("mac") != net_infos.get("mac"):
-                    continue
+            while time.time() < started_at + timeout:
+                leases = network.DHCPLeases()
+                for lease in sorted(leases, key=lambda item: item.get("expirytime"), reverse=True):
+                    if lease.get("mac") != net_infos.get("mac"):
+                        continue
 
-                return lease.get("ipaddr")
+                    log("found domain IP address after %.2f seconds" % (time.time()-started_at))
+
+                    return lease.get("ipaddr")
+
+                # wait for 200ms before re-trying
+                time.sleep(.2)
 
         return None
 
@@ -324,7 +331,7 @@ class LibvirtEventsHandler(object):
         cid = "vm-%s" % (self.libvirt.getId(dom))
         name = self.libvirt.getName(dom)
         hostname = name
-        ipaddress = self.libvirt.getIPAddress(dom)
+        ipaddress = self.libvirt.getIPAddress(dom, timeout=10)
         network = self.libvirt.getNetworkIface(dom)
         dns_domain = self.libvirt.getLabel(dom, "dns.domain", DNS_DOMAIN)
         dns_use_wildcard = self.libvirt.getLabel(dom, "dns.wildcard", DNS_WILDCARD).lower()

--- a/dalidock
+++ b/dalidock
@@ -23,6 +23,7 @@ DOCKER_SOCKET = os.getenv("DOCKER_SOCKET", "unix://var/run/docker.sock")
 
 # libvirt default values
 LIBVIRT_SOCKET = os.getenv("LIBVIRT_SOCKET", "/var/run/libvirt/libvirt-sock-ro")
+LIBVIRT_IP_TIMEOUT = float(os.getenv("LIBVIRT_IP_TIMEOUT", "30.0"))
 
 # DNS default values
 DNS_DOMAIN = os.getenv("DNS_DOMAIN", "local")
@@ -341,6 +342,11 @@ class LibvirtEventsHandler(object):
             self.handleDomainSafe(dom, "Started")
 
     def handleDomainSafe(self, dom, event):
+        # if domain has just been started, wait for IP address to be known before trying to lock
+        # config for update (other newly started container/domain may already be ready)
+        if event == "Started":
+            log("wait for domain %s DHCP lease to appear" % (self.libvirt.getName(dom)))
+            _ = self.libvirt.getIPAddress(dom, timeout=LIBVIRT_IP_TIMEOUT)
 
         with self.config_lock:
             self.handleDomain(dom, event)
@@ -349,17 +355,13 @@ class LibvirtEventsHandler(object):
         cid = "libvirt-qemu-%s" % (self.libvirt.getId(dom))
         name = self.libvirt.getName(dom)
         hostname = name
-        ipaddress = self.libvirt.getIPAddress(dom, timeout=10)
+        ipaddress = self.libvirt.getIPAddress(dom)
         network = self.libvirt.getNetworkIface(dom)
         dns_domain = self.libvirt.getLabel(dom, "dns.domain", DNS_DOMAIN)
         dns_use_wildcard = self.libvirt.getLabel(dom, "dns.wildcard", DNS_WILDCARD).lower()
         dns_aliases = self.libvirt.getLabel(dom, "dns.aliases", "")
         lb_domain = self.libvirt.getLabel(dom, "lb.domain", LB_DOMAIN)
         lb_http_map = self.libvirt.getLabel(dom, "lb.http", "")
-
-        if ipaddress is None:
-            log("Skipping domain %s as no IP address have been detected" % (name))
-            return
 
         if dns_use_wildcard in ["1", "true", "yes"]:
             dns_use_wildcard = True
@@ -372,6 +374,10 @@ class LibvirtEventsHandler(object):
         )
 
         if event == "Started":
+            if ipaddress is None:
+                log("Skipping domain %s as no IP address have been detected" % (name))
+                return
+
             self.dns.add(
                 cid, hostname, ipaddress, network, dns_domain, name, dns_aliases, dns_use_wildcard
             )

--- a/dalidock
+++ b/dalidock
@@ -5,9 +5,7 @@ __author__ = "Lionel Nicolas"
 __copyright__ = "Copyright 2016-2019 Lionel Nicolas"
 __license__ = "Apache License Version 2.0"
 
-import docker
 import json
-import libvirt
 import os
 import pprint
 import sys
@@ -17,6 +15,8 @@ import subprocess
 import time
 import threading
 import xml.etree.ElementTree
+import libvirt
+import docker
 
 # docker default values
 DOCKER_SOCKET = os.getenv("DOCKER_SOCKET", "unix://var/run/docker.sock")

--- a/dalidock
+++ b/dalidock
@@ -313,6 +313,10 @@ class LibvirtEventsHandler(object):
         if str(DOM_EVENTS[event]) in ["Started", "Stopped"]:
             self.handleDomain(dom, str(DOM_EVENTS[event]))
 
+        # if definition is updated while domain is running, emulate 'Started' event
+        elif str(DOM_EVENTS[event]) == "Defined" and dom.state()[0] == libvirt.VIR_DOMAIN_RUNNING:
+            self.handleDomain(dom, "Started")
+
     def errorCallback(self, unused, error):
         # ignore empty metadata errors
         if (error[0] == libvirt.VIR_ERR_NO_DOMAIN_METADATA and error[1] == libvirt.VIR_FROM_DOMAIN):

--- a/dalidock
+++ b/dalidock
@@ -7,7 +7,6 @@ __license__ = "Apache License Version 2.0"
 
 import json
 import os
-import pprint
 import sys
 import signal
 import socket
@@ -717,8 +716,7 @@ class DnsEntries:
                 del self.entries[entry]
 
     def show(self):
-        pp = pprint.PrettyPrinter(indent=4)
-        pp.pprint(self.entries)
+        print(json.dumps(self.entries, indent=4, sort_keys=True))
 
     def generate(self):
         etc_hosts = ""
@@ -831,8 +829,7 @@ class LoadbalancerEntries:
             del self.entries[cid]
 
     def show(self):
-        pp = pprint.PrettyPrinter(indent=4)
-        pp.pprint(self.entries)
+        print(json.dumps(self.entries, indent=4, sort_keys=True))
 
     def generate(self):
         http_conf = dict()

--- a/dalidock
+++ b/dalidock
@@ -186,7 +186,7 @@ class LibvirtQemuClient(object):
         # return domain name
         return dom.name()
 
-    def getIPAddress(self, dom, timeout=0):
+    def getIPAddress(self, dom, timeout=None):
         # return domain main IP address
 
         net_infos = self.getNetworkInfos(dom)
@@ -196,15 +196,23 @@ class LibvirtQemuClient(object):
             if not hasattr(network, "bridgeName") or network.bridgeName() != net_infos.get("iface"):
                 continue
 
-            while time.time() < started_at + timeout:
+            while timeout is None or time.time() < started_at + timeout:
                 leases = network.DHCPLeases()
                 for lease in sorted(leases, key=lambda item: item.get("expirytime"), reverse=True):
                     if lease.get("mac") != net_infos.get("mac"):
                         continue
 
-                    log("found domain IP address after %.2f seconds" % (time.time()-started_at))
+                    if timeout is not None:
+                        log(
+                            "found domain IP address after %.2f seconds"
+                            % (time.time() - started_at)
+                        )
 
                     return lease.get("ipaddr")
+
+                # no timeout set, return after first attempt
+                if timeout is None:
+                    return None
 
                 # wait for 200ms before re-trying
                 time.sleep(.2)

--- a/dalidock
+++ b/dalidock
@@ -180,7 +180,7 @@ class LibvirtQemuClient(object):
 
     def getId(self, dom):
         # return domain id
-        return dom.ID()
+        return dom.UUIDString()
 
     def getName(self, dom):
         # return domain name
@@ -332,7 +332,7 @@ class LibvirtEventsHandler(object):
             self.handleDomain(dom, "Started")
 
     def handleDomain(self, dom, event):
-        cid = "vm-%s" % (self.libvirt.getId(dom))
+        cid = "libvirt-qemu-%s" % (self.libvirt.getId(dom))
         name = self.libvirt.getName(dom)
         hostname = name
         ipaddress = self.libvirt.getIPAddress(dom, timeout=10)

--- a/dalidock
+++ b/dalidock
@@ -44,7 +44,7 @@ DNSMASQ_HOSTS_FILE = os.getenv("DNSMASQ_HOSTS_FILE", "/run/dnsmasq/hosts/docker"
 def get_own_ip_address(from_env=False):
     forced_external_ip = os.getenv("EXTERNAL_IP")
 
-    if forced_external_ip is not None and from_env == True:
+    if forced_external_ip is not None and from_env:
         return forced_external_ip
 
     # get default network interface
@@ -54,20 +54,17 @@ def get_own_ip_address(from_env=False):
 
     if not iface:
         raise Exception("Fail to get default network interface")
-    else:
-        iface = iface.decode("utf8").split("\n")[0]
 
     # get IP address of default network interface
+    iface = iface.decode("utf8").split("\n")[0]
     ipaddr = subprocess.check_output(
         "ip addr show dev %s | awk -F'[ \t/]+' '/inet / { print $3; exit; }'" % (iface), shell=True
     )
 
     if not ipaddr:
         raise Exception("Fail to get interface %s IP address" % (iface))
-    else:
-        ipaddr = ipaddr.decode("utf8").split("\n")[0]
 
-    return ipaddr
+    return ipaddr.decode("utf8").split("\n")[0]
 
 
 def get_process_info():
@@ -90,13 +87,13 @@ def fatal(msg, hostname=False):
     sys.exit(1)
 
 
-def sighandler(sig, frame):
+def sighandler(_sig, _frame):
     print("")
     sys.exit(0)
 
 
 # https://github.com/libvirt/libvirt-python/blob/master/examples/event-test.py#L494
-class Description(object):
+class Description:
     __slots__ = ("desc", "args")
 
     def __init__(self, *args, **kwargs):
@@ -114,7 +111,8 @@ class Description(object):
 
         if isinstance(data, str):
             return self.__class__(desc=data)
-        elif isinstance(data, (list, tuple)):
+
+        if isinstance(data, (list, tuple)):
             desc, args = data
             return self.__class__(*args, desc=desc)
 
@@ -150,9 +148,9 @@ DOM_EVENTS = Description(
 )
 
 
-class LibvirtQemuClient(object):
-    def __init__(self, socket="unix://var/run/docker.sock"):
-        self.socket = socket
+class LibvirtQemuClient:
+    def __init__(self, socket_path="unix://var/run/docker.sock"):
+        self.socket = socket_path
         self.conn = libvirt.openReadOnly(name="qemu:///system?socket=%s" % (self.socket))
 
         self.showInformations()
@@ -174,15 +172,17 @@ class LibvirtQemuClient(object):
         try:
             dom = self.conn.lookupByName(domainid)
 
-        except libvirt.libvirtError as e:
+        except libvirt.libvirtError:
             dom = None
 
         return dom
 
+    # pylint: disable=no-self-use
     def getId(self, dom):
         # return domain id
         return dom.UUIDString()
 
+    # pylint: disable=no-self-use
     def getName(self, dom):
         # return domain name
         return dom.name()
@@ -216,7 +216,7 @@ class LibvirtQemuClient(object):
                     return None
 
                 # wait for 200ms before re-trying
-                time.sleep(.2)
+                time.sleep(0.2)
 
         return None
 
@@ -241,12 +241,6 @@ class LibvirtQemuClient(object):
         return self.getNetworkInfos(dom).get("iface")
 
     def getLabels(self, dom):
-        # dns.domain
-        # dns.wildcard
-        # dns.aliases
-        # lb.domain
-        # lb.http
-
         try:
             xml_labels = dom.metadata(
                 type=libvirt.VIR_DOMAIN_METADATA_ELEMENT,
@@ -259,8 +253,6 @@ class LibvirtQemuClient(object):
         return dict(xml.etree.ElementTree.fromstring(xml_labels).items())
 
     def getLabel(self, dom, name, default=False):
-        # return container's label 'name'
-
         labels = self.getLabels(dom)
 
         if name not in labels:
@@ -269,7 +261,7 @@ class LibvirtQemuClient(object):
         return labels[name]
 
 
-class LibvirtEventsHandler(object):
+class LibvirtEventsHandler:
     def __init__(self, dns_entries, lb_entries, config_lock):
         # note: event loop need to be registered before opening connection to libvirt
         libvirt.virEventRegisterDefaultImpl()
@@ -301,9 +293,6 @@ class LibvirtEventsHandler(object):
         # get all other running containers, then fix/update their network configuration if needed
         self.loadAllDomains()
 
-        # while self.loop and self.libvirt.conn.isAlive() == 1:
-        #    time.sleep(.1)
-
     def eventLoopRun(self):
         while self.loop:
             libvirt.virEventRunDefaultImpl()
@@ -314,7 +303,7 @@ class LibvirtEventsHandler(object):
         self.event_loop_thread.setDaemon(True)
         self.event_loop_thread.start()
 
-    def eventCallback(self, conn, dom, event, detail, opaque):
+    def eventCallback(self, _conn, dom, event, detail, _opaque):
         log(
             "libvirt event: domain %s(%s) got %s (%s)"
             % (dom.name(), dom.ID(), DOM_EVENTS[event], DOM_EVENTS[event][detail])
@@ -327,12 +316,17 @@ class LibvirtEventsHandler(object):
         elif str(DOM_EVENTS[event]) == "Defined" and dom.state()[0] == libvirt.VIR_DOMAIN_RUNNING:
             self.handleDomainSafe(dom, "Started")
 
-    def errorCallback(self, unused, error):
+    # pylint: disable=no-self-use
+    def errorCallback(self, _, cb_error):
         # ignore empty metadata errors
-        if (error[0] == libvirt.VIR_ERR_NO_DOMAIN_METADATA and error[1] == libvirt.VIR_FROM_DOMAIN):
+        # pylint: disable=bad-continuation
+        if (
+            cb_error[0] == libvirt.VIR_ERR_NO_DOMAIN_METADATA
+            and cb_error[1] == libvirt.VIR_FROM_DOMAIN
+        ):
             return
 
-        log("libvirt error: %s" % (error[2]))
+        log("libvirt error: %s" % (cb_error[2]))
 
     def loadAllDomains(self):
         for dom in self.libvirt.conn.listAllDomains():
@@ -344,7 +338,7 @@ class LibvirtEventsHandler(object):
     def handleDomainSafe(self, dom, event, start_thread=True):
         # re-call in background thread
         if start_thread:
-            return threading.Thread(
+            threading.Thread(
                 target=self.handleDomainSafe,
                 args=(dom, event),
                 kwargs={"start_thread": False},
@@ -372,6 +366,7 @@ class LibvirtEventsHandler(object):
         lb_domain = self.libvirt.getLabel(dom, "lb.domain", LB_DOMAIN)
         lb_http_map = self.libvirt.getLabel(dom, "lb.http", "")
 
+        # pylint: disable=simplifiable-if-statement
         if dns_use_wildcard in ["1", "true", "yes"]:
             dns_use_wildcard = True
         else:
@@ -409,7 +404,7 @@ class LibvirtEventsHandler(object):
         self.loop = False
 
 
-class DockerClient(object):
+class DockerClient:
     def __init__(self, url="unix://var/run/docker.sock"):
         self.url = url
         self.conn = docker.Client(base_url=self.url)
@@ -446,27 +441,32 @@ class DockerClient(object):
 
         return data
 
+    # pylint: disable=no-self-use
     def getId(self, data):
         # return container id
         return data["Id"]
 
+    # pylint: disable=no-self-use
     def getName(self, data):
         # return container name
         return data["Name"].replace("/", "")
 
+    # pylint: disable=no-self-use
     def getHostname(self, data):
         # return container hostname
         return data["Config"]["Hostname"]
 
+    # pylint: disable=no-self-use
     def getIPAddress(self, data):
         # return container main IP address
 
         for net in data["NetworkSettings"]["Networks"]:
             if net == "host":
                 return get_own_ip_address()
-            else:
-                return data["NetworkSettings"]["Networks"][net]["IPAddress"]
 
+            return data["NetworkSettings"]["Networks"][net]["IPAddress"]
+
+    # pylint: disable=no-self-use
     def getNetworkName(self, data):
         # return first network name
 
@@ -475,6 +475,7 @@ class DockerClient(object):
 
         return False
 
+    # pylint: disable=no-self-use
     def getLabels(self, data):
         # return container's labels
         return data["Config"]["Labels"]
@@ -490,7 +491,7 @@ class DockerClient(object):
         return labels[name]
 
 
-class DockerEventsHandler(object):
+class DockerEventsHandler:
     def __init__(self, dns_entries, lb_entries, config_lock):
         self.docker = DockerClient(DOCKER_SOCKET)
         self.myid = self.getMyCid()
@@ -577,7 +578,7 @@ class DockerEventsHandler(object):
         evt = json.loads(evt)
 
         if "Type" not in evt.keys() or evt["Type"] != "container":
-            # this event is useless because not related to container state, skipping (fix for docker 1.10+)
+            # this event is useless because not related to container state
             return
 
         containerid = evt["id"]
@@ -612,6 +613,7 @@ class DockerEventsHandler(object):
         lb_http_map = self.docker.getLabel(data, "lb.http", "")
         lb_tcp_map = self.docker.getLabel(data, "lb.tcp", "")
 
+        # pylint: disable=simplifiable-if-statement
         if dns_use_wildcard in ["1", "true", "yes"]:
             dns_use_wildcard = True
         else:
@@ -642,7 +644,7 @@ class DockerEventsHandler(object):
         self.dns.show()
 
 
-class DnsEntries(object):
+class DnsEntries:
     def __init__(self):
         self.myid = None
         self.entries = dict()
@@ -731,6 +733,7 @@ class DnsEntries(object):
             hosts.append("%s.%s" % (data["hostname"], data["domain"]))
 
             # loop on host names
+            # pylint: disable=bad-continuation
             for host in [
                 "%s" % (data["hostname"]),
                 "%s.%s" % (data["name"], data["domain"]),
@@ -790,14 +793,16 @@ class DnsEntries(object):
 
             self.restart()
 
+    # pylint: disable=no-self-use
     def reload(self):
         os.system("sv hup dnsmasq")
 
+    # pylint: disable=no-self-use
     def restart(self):
         os.system("sv restart dnsmasq")
 
 
-class LoadbalancerEntries(object):
+class LoadbalancerEntries:
     def __init__(self, dns):
         self.dns = dns
         self.entries = dict()
@@ -908,6 +913,7 @@ class LoadbalancerEntries(object):
 
             self.restart()
 
+    # pylint: disable=no-self-use
     def restart(self):
         os.system("haproxy-start %s" % (HAPROXY_CONFIG_FILE))
 

--- a/dalidock
+++ b/dalidock
@@ -7,15 +7,22 @@ __license__ = "Apache License Version 2.0"
 
 import docker
 import json
+import libvirt
 import os
 import pprint
 import sys
 import signal
 import socket
 import subprocess
+import time
+import threading
+import xml.etree.ElementTree
 
 # docker default values
 DOCKER_SOCKET = os.getenv("DOCKER_SOCKET", "unix://var/run/docker.sock")
+
+# libvirt default values
+LIBVIRT_SOCKET = os.getenv("LIBVIRT_SOCKET", "/var/run/libvirt/libvirt-sock-ro")
 
 # DNS default values
 DNS_DOMAIN = os.getenv("DNS_DOMAIN", "local")
@@ -85,6 +92,272 @@ def fatal(msg, hostname=False):
 def sighandler(sig, frame):
     print("")
     sys.exit(0)
+
+
+# https://github.com/libvirt/libvirt-python/blob/master/examples/event-test.py#L494
+class Description(object):
+    __slots__ = ("desc", "args")
+
+    def __init__(self, *args, **kwargs):
+        self.desc = kwargs.get("desc")
+        self.args = args
+
+    def __str__(self):  # type: () -> str
+        return self.desc
+
+    def __getitem__(self, item):  # type: (int) -> str
+        try:
+            data = self.args[item]
+        except IndexError:
+            return self.__class__(desc=str(item))
+
+        if isinstance(data, str):
+            return self.__class__(desc=data)
+        elif isinstance(data, (list, tuple)):
+            desc, args = data
+            return self.__class__(*args, desc=desc)
+
+        raise TypeError(args)
+
+
+DOM_EVENTS = Description(
+    ("Defined", ("Added", "Updated", "Renamed", "Snapshot")),
+    ("Undefined", ("Removed", "Renamed")),
+    ("Started", ("Booted", "Migrated", "Restored", "Snapshot", "Wakeup")),
+    (
+        "Suspended",
+        (
+            "Paused",
+            "Migrated",
+            "IOError",
+            "Watchdog",
+            "Restored",
+            "Snapshot",
+            "API error",
+            "Postcopy",
+            "Postcopy failed",
+        ),
+    ),
+    ("Resumed", ("Unpaused", "Migrated", "Snapshot", "Postcopy")),
+    (
+        "Stopped",
+        ("Shutdown", "Destroyed", "Crashed", "Migrated", "Saved", "Failed", "Snapshot", "Daemon"),
+    ),
+    ("Shutdown", ("Finished", "On guest request", "On host request")),
+    ("PMSuspended", ("Memory", "Disk")),
+    ("Crashed", ("Panicked",)),
+)
+
+
+class LibvirtQemuClient(object):
+    def __init__(self, socket="unix://var/run/docker.sock"):
+        self.socket = socket
+        self.conn = libvirt.openReadOnly(name="qemu:///system?socket=%s" % (self.socket))
+
+        self.showInformations()
+
+    def showInformations(self):
+        host_infos = self.conn.getInfo()
+
+        log("----- LIBVIRT INFOS -----")
+        log("Model:                %s" % (host_infos[0]))
+        log("Memory size:          %s MB" % (host_infos[1]))
+        log("Number of CPUs:       %s" % (host_infos[2]))
+        log("MHz of CPUs:          %s" % (host_infos[3]))
+        log("NUMA nodes:           %s" % (host_infos[4]))
+        log("CPU sockets:          %s" % (host_infos[5]))
+        log("CPU cores per socket: %s" % (host_infos[6]))
+        log("CPU threads per core: %s" % (host_infos[7]))
+
+    def getDomain(self, domainid):
+        try:
+            dom = self.conn.lookupByName(domainid)
+
+        except libvirt.libvirtError as e:
+            error("libvirt: %s" % (str(e)))
+            dom = None
+
+        return dom
+
+    def getId(self, dom):
+        # return domain id
+        return dom.ID()
+
+    def getName(self, dom):
+        # return domain name
+        return dom.name()
+
+    def getIPAddress(self, dom):
+        # return domain main IP address
+
+        net_infos = self.getNetworkInfos(dom)
+
+        for network in self.conn.listAllNetworks():
+            if not hasattr(network, "bridgeName") or network.bridgeName() != net_infos.get("iface"):
+                continue
+
+            leases = network.DHCPLeases()
+            for lease in sorted(leases, key=lambda item: item.get("expirytime"), reverse=True):
+                if lease.get("mac") != net_infos.get("mac"):
+                    continue
+
+                return lease.get("ipaddr")
+
+        return None
+
+    def getNetworkInfos(self, dom):
+        # return first network name
+
+        xml_root = xml.etree.ElementTree.fromstring(dom.XMLDesc())
+        xml_iface = xml_root.find(".//interface")
+
+        if xml_iface is None or xml_iface.get("type") != "bridge":
+            return dict()
+
+        mac_addr = xml_iface.find(".//mac").get("address")
+        bridge_iface = xml_iface.find(".//source").get("bridge")
+
+        return {"mac": mac_addr, "iface": bridge_iface}
+
+    def getNetworkMac(self, dom):
+        return self.getNetworkInfos(dom).get("mac")
+
+    def getNetworkIface(self, dom):
+        return self.getNetworkInfos(dom).get("iface")
+
+    def getLabels(self, dom):
+        # dns.domain
+        # dns.wildcard
+        # dns.aliases
+        # lb.domain
+        # lb.http
+
+        try:
+            xml_labels = dom.metadata(
+                type=libvirt.VIR_DOMAIN_METADATA_ELEMENT,
+                uri="http://github.com/lionelnicolas/dalidock",
+                flags=2,
+            )
+        except libvirt.libvirtError:
+            return dict()
+
+        return dict(xml.etree.ElementTree.fromstring(xml_labels).items())
+
+    def getLabel(self, dom, name, default=False):
+        # return container's label 'name'
+
+        labels = self.getLabels(dom)
+
+        if name not in labels:
+            return default
+
+        return labels[name]
+
+
+class LibvirtEventsHandler(object):
+    def __init__(self, dns_entries, lb_entries):
+        # note: event loop need to be registered before opening connection to libvirt
+        libvirt.virEventRegisterDefaultImpl()
+
+        if not os.path.exists(LIBVIRT_SOCKET):
+            self.libvirt = None
+            return
+
+        self.libvirt = LibvirtQemuClient(LIBVIRT_SOCKET)
+        self.dns = dns_entries
+        self.lb = lb_entries
+        self.event_loop_thread = None
+        self.loop = True
+
+    def run(self):
+        if self.libvirt is None:
+            log("Skipping libvirt events handler as %s not found" % (LIBVIRT_SOCKET))
+            return
+
+        log("Starting libvirt events handler")
+
+        self.eventLoopStart()
+        self.libvirt.conn.domainEventRegister(self.eventCallback, None)
+
+        # get all other running containers, then fix/update their network configuration if needed
+        self.loadAllDomains()
+
+        # while self.loop and self.libvirt.conn.isAlive() == 1:
+        #    time.sleep(.1)
+
+    def eventLoopRun(self):
+        while self.loop:
+            libvirt.virEventRunDefaultImpl()
+
+    def eventLoopStart(self):
+        self.event_loop_thread = threading.Thread(target=self.eventLoopRun, name="libvirtEventLoop")
+
+        self.event_loop_thread.setDaemon(True)
+        self.event_loop_thread.start()
+
+    def eventCallback(self, conn, dom, event, detail, opaque):
+        log(
+            "libvirt event: domain %s(%s) got %s (%s)"
+            % (dom.name(), dom.ID(), DOM_EVENTS[event], DOM_EVENTS[event][detail])
+        )
+
+        if str(DOM_EVENTS[event]) in ["Started", "Stopped"]:
+            self.handleDomain(dom, str(DOM_EVENTS[event]))
+
+    def loadAllDomains(self):
+        for dom in self.libvirt.conn.listAllDomains():
+            if dom.state()[0] != libvirt.VIR_DOMAIN_RUNNING:
+                continue
+
+            self.handleDomain(dom, "Started")
+
+    def handleDomain(self, dom, event):
+        cid = "vm-%s" % (self.libvirt.getId(dom))
+        name = self.libvirt.getName(dom)
+        hostname = name
+        ipaddress = self.libvirt.getIPAddress(dom)
+        network = self.libvirt.getNetworkIface(dom)
+        dns_domain = self.libvirt.getLabel(dom, "dns.domain", DNS_DOMAIN)
+        dns_use_wildcard = self.libvirt.getLabel(dom, "dns.wildcard", DNS_WILDCARD).lower()
+        dns_aliases = self.libvirt.getLabel(dom, "dns.aliases", "")
+        lb_domain = self.libvirt.getLabel(dom, "lb.domain", LB_DOMAIN)
+        lb_http_map = self.libvirt.getLabel(dom, "lb.http", "")
+
+        if ipaddress is None:
+            log("Skipping domain %s as no IP address have been detected" % (name))
+            return
+
+        if dns_use_wildcard in ["1", "true", "yes"]:
+            dns_use_wildcard = True
+        else:
+            dns_use_wildcard = False
+
+        log(
+            "name=%-10s hostname=%-10s ip=%-15s net=%-10s domain=%-10s use_wildcard=%s"
+            % (name, hostname, ipaddress, network, dns_domain, dns_use_wildcard)
+        )
+
+        if event == "Started":
+            self.dns.add(
+                cid, hostname, ipaddress, network, dns_domain, name, dns_aliases, dns_use_wildcard
+            )
+            self.lb.add(cid, hostname, ipaddress, lb_domain, lb_http_map)
+
+        elif event == "Stopped":
+            self.dns.remove(cid)
+            self.lb.remove(cid)
+
+        self.lb.update()
+        self.dns.update()
+
+        self.dns.show()
+
+    def stop(self):
+        if self.libvirt is None:
+            return
+
+        log("Stopping libvirt event handler")
+        self.loop = False
 
 
 class DockerClient(object):
@@ -169,11 +442,11 @@ class DockerClient(object):
 
 
 class DockerEventsHandler(object):
-    def __init__(self):
+    def __init__(self, dns_entries, lb_entries):
         self.docker = DockerClient(DOCKER_SOCKET)
         self.myid = self.getMyCid()
-        self.dns = DnsEntries(self.myid)
-        self.lb = LoadbalancerEntries(self.myid, self.dns)
+        self.dns = dns_entries
+        self.lb = lb_entries
         self.loop = True
 
     def serve(self):
@@ -283,6 +556,8 @@ class DockerEventsHandler(object):
         dns_aliases = self.docker.getLabel(data, "dns.aliases", "")
         lb_domain = self.docker.getLabel(data, "lb.domain", LB_DOMAIN)
         lb_http_map = self.docker.getLabel(data, "lb.http", "")
+        lb_tcp_map = self.docker.getLabel(data, "lb.tcp", "")
+
         if dns_use_wildcard in ["1", "true", "yes"]:
             dns_use_wildcard = True
         else:
@@ -310,13 +585,18 @@ class DockerEventsHandler(object):
         self.lb.update()
         self.dns.update()
 
+        self.dns.show()
+
 
 class DnsEntries(object):
-    def __init__(self, myid):
-        self.myid = myid
+    def __init__(self):
+        self.myid = None
         self.entries = dict()
         self.cached_etc_hosts = ""
         self.cached_wildcards = ""
+
+    def setMyId(self, myid):
+        self.myid = myid
 
     def add(self, cid, hostname, ipaddress, network, domain, name, aliases, use_wildcard):
         entry = {
@@ -464,8 +744,7 @@ class DnsEntries(object):
 
 
 class LoadbalancerEntries(object):
-    def __init__(self, myid, dns):
-        self.myid = myid
+    def __init__(self, dns):
         self.dns = dns
         self.entries = dict()
         self.myip = get_own_ip_address(from_env=True)
@@ -584,8 +863,23 @@ signal.signal(signal.SIGTERM, sighandler)
 
 
 def main():
-    evt_handler = DockerEventsHandler()
-    evt_handler.serve()
+    # prepare data models
+    dns_entries = DnsEntries()
+    lb_entries = LoadbalancerEntries(dns_entries)
+
+    # prepare event handlers
+    libvirt_evt_handler = LibvirtEventsHandler(dns_entries, lb_entries)
+    docker_evt_handler = DockerEventsHandler(dns_entries, lb_entries)
+
+    # update myid attribute (gotten from docker client)
+    dns_entries.setMyId(docker_evt_handler.myid)
+
+    # start event handlers
+    libvirt_evt_handler.run()
+    docker_evt_handler.serve()
+
+    # stop libvirt handler
+    libvirt_evt_handler.stop()
 
 
 if __name__ == "__main__":

--- a/dalidock
+++ b/dalidock
@@ -377,7 +377,7 @@ class LibvirtEventsHandler:
         ):
             return
 
-        log("libvirt error: %s" % (cb_error[2]))
+        log("libvirt error: [%d, %d] %s" % (cb_error[0], cb_error[1], cb_error[2]))
 
     def loadAllDomains(self):
         for dom in self.libvirt.conn.listAllDomains():

--- a/dalidock
+++ b/dalidock
@@ -174,7 +174,6 @@ class LibvirtQemuClient(object):
             dom = self.conn.lookupByName(domainid)
 
         except libvirt.libvirtError as e:
-            error("libvirt: %s" % (str(e)))
             dom = None
 
         return dom
@@ -259,6 +258,9 @@ class LibvirtEventsHandler(object):
         # note: event loop need to be registered before opening connection to libvirt
         libvirt.virEventRegisterDefaultImpl()
 
+        # register error handler
+        libvirt.registerErrorHandler(self.errorCallback, None)
+
         if not os.path.exists(LIBVIRT_SOCKET):
             self.libvirt = None
             return
@@ -303,6 +305,13 @@ class LibvirtEventsHandler(object):
 
         if str(DOM_EVENTS[event]) in ["Started", "Stopped"]:
             self.handleDomain(dom, str(DOM_EVENTS[event]))
+
+    def errorCallback(self, unused, error):
+        # ignore empty metadata errors
+        if (error[0] == libvirt.VIR_ERR_NO_DOMAIN_METADATA and error[1] == libvirt.VIR_FROM_DOMAIN):
+            return
+
+        log("libvirt error: %s" % (error[2]))
 
     def loadAllDomains(self):
         for dom in self.libvirt.conn.listAllDomains():

--- a/dalidock
+++ b/dalidock
@@ -411,6 +411,7 @@ class LibvirtEventsHandler:
                 kwargs={"start_thread": False},
                 daemon=True,
             ).start()
+            return
 
         # if domain has just been started, wait for IP address to be known before trying to lock
         # config for update (other newly started container/domain may already be ready)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 docker-py==1.10.6
+libvirt-python==5.7.0


### PR DESCRIPTION
To replicate what `dalidock` is doing with docker labels, this uses libvirt XML metadata to configure load balancing and DNS aliases.